### PR TITLE
Added .editorconfig to be used for Fabric projects, and updated the IDEA formatter.

### DIFF
--- a/guidelines/.editorconfig
+++ b/guidelines/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+tab_width = 4
+
+[*.gradle]
+indent_style = tab
+
+[*.java]
+indent_style = tab
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.properties]
+indent_style = space
+indent_size = 2
+
+[.editorconfig]
+indent_style = space
+indent_size = 4

--- a/guidelines/intellij/FabricFormat.xml
+++ b/guidelines/intellij/FabricFormat.xml
@@ -1,4 +1,4 @@
-<code_scheme name="FabricFormat">
+<code_scheme name="FabricFormat" version="173">
   <option name="AUTODETECT_INDENTS" value="false" />
   <option name="OTHER_INDENT_OPTIONS">
     <value>
@@ -22,6 +22,13 @@
   <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
   <JavaCodeStyleSettings>
     <option name="CLASS_NAMES_IN_JAVADOC" value="3" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="5" />
+    <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
+    <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
+    <option name="JD_P_AT_EMPTY_LINES" value="false" />
+    <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
+    <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
+    <option name="JD_INDENT_ON_CONTINUATION" value="true" />
   </JavaCodeStyleSettings>
   <MarkdownNavigatorCodeStyleSettings>
     <option name="RIGHT_MARGIN" value="72" />


### PR DESCRIPTION
Mostly adds a basic .editorconfig file to be used by people that aren't using IDEA and therefore the IDEA formatter. Obviously has way fewer features, but it is supported by every decent editor that exists. Once this gets merged, I will PR this file to the other repos as well. This should cover all files that we care about.

Also updates the IDEA formatter to stuff in the latest version.